### PR TITLE
Implemented function of insertion of multiple readings and test for it.

### DIFF
--- a/pkg/protocol/utlis/insert.go
+++ b/pkg/protocol/utlis/insert.go
@@ -4,6 +4,13 @@ import (
 	"github.com/Domilz/d7017e-mesh-network/pkg/protocol/pb"
 )
 
+func InsertMultipleReadings(readings map[string]*pb.Reading, state *pb.State) {
+	for _, reading := range readings {
+		InsertSingleReading(state, reading)
+	}
+
+}
+
 func InsertSingleReading(state *pb.State, reading *pb.Reading) {
 	_, key := state.Readings[reading.TagId]
 

--- a/pkg/protocol/utlis/insert_test.go
+++ b/pkg/protocol/utlis/insert_test.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func TestInsertReading(t *testing.T) {
+func TestInsertSingleReading(t *testing.T) {
 
 	mockReading := &pb.Reading{
 		TagId:    "MOCKTAG",
@@ -38,7 +38,7 @@ func TestInsertReading(t *testing.T) {
 
 	InsertSingleReading(mockState, mockReading2)
 
-	mockState2 := &pb.State{
+	expectedMockState := &pb.State{
 		TagId: "666",
 		Readings: map[string]*pb.Reading{
 			mockReading.TagId:  mockReading,
@@ -46,11 +46,11 @@ func TestInsertReading(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, mockState2, mockState)
+	assert.Equal(t, expectedMockState, mockState)
 
 }
 
-func TestLessTimeDontInsert(t *testing.T) {
+func TestLessTimeDontInsertSingleReading(t *testing.T) {
 
 	time := timestamppb.Now().Seconds
 	time2 := time / 100
@@ -86,7 +86,7 @@ func TestLessTimeDontInsert(t *testing.T) {
 
 }
 
-func TestMoreTimeInsert(t *testing.T) {
+func TestMoreTimeInsertSingleReading(t *testing.T) {
 
 	time := timestamppb.Now().Seconds
 	time2 := time * 100
@@ -119,5 +119,64 @@ func TestMoreTimeInsert(t *testing.T) {
 	InsertSingleReading(mockState, mockReading2)
 
 	assert.Equal(t, time2, mockState.Readings[mockReading.TagId].Ts.Seconds)
+
+}
+
+func TestInsertMultipleReading(t *testing.T) {
+
+	mockReading := &pb.Reading{
+		TagId:    "MOCKTAG",
+		DeviceId: "321",
+		Rssi:     69,
+		Ts: &timestamp.Timestamp{
+			Seconds: timestamppb.Now().Seconds,
+		},
+	}
+
+	mockReading2 := &pb.Reading{
+		TagId:    "MOCKTAG2",
+		DeviceId: "3212",
+		Rssi:     13,
+		Ts: &timestamp.Timestamp{
+			Seconds: timestamppb.Now().Seconds,
+		},
+	}
+
+	mockReading3 := &pb.Reading{
+		TagId:    "MOCKTAG3",
+		DeviceId: "3213",
+		Rssi:     10,
+		Ts: &timestamp.Timestamp{
+			Seconds: timestamppb.Now().Seconds,
+		},
+	}
+
+	mockState := &pb.State{
+		TagId: "666",
+		Readings: map[string]*pb.Reading{
+			mockReading.TagId:  mockReading,
+			mockReading2.TagId: mockReading2,
+		},
+	}
+
+	mockState2 := &pb.State{
+		TagId: "669",
+		Readings: map[string]*pb.Reading{
+			mockReading3.TagId: mockReading3,
+		},
+	}
+
+	InsertMultipleReadings(mockState.Readings, mockState2)
+
+	expectedMockState := &pb.State{
+		TagId: "669",
+		Readings: map[string]*pb.Reading{
+			mockReading3.TagId: mockReading3,
+			mockReading.TagId:  mockReading,
+			mockReading2.TagId: mockReading2,
+		},
+	}
+
+	assert.Equal(t, expectedMockState, mockState2)
 
 }


### PR DESCRIPTION
- Function for insertion of multiple readings so that there is no need to call on the function **InsertSingleReading** for a large amount of readings. It takes a map of readings, that are to be inserted, and a **state** where the readings shall be inserted into.
- A test for the method.