### PR TITLE
Added tests for statehandler

### DIFF
--- a/internal/protocol/utils/state_hander_test.go
+++ b/internal/protocol/utils/state_hander_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"sort"
+	"sync"
 	"testing"
 
 	pb "github.com/Domilz/d7017e-mesh-network/internal/protocol/protofiles/tag"
@@ -10,7 +11,15 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func TestInsertSingleReading(t *testing.T) {
+func TestInnitStateHandler(t *testing.T) {
+	sh := StateHandler{}
+	sh.initStateHandler("666")
+
+	shMock := StateHandler{"666", make(map[string]*pb.Reading), sync.RWMutex{}}
+	assert.Equal(t, sh, shMock)
+
+}
+func TestGetReading(t *testing.T) {
 
 	mockReading := &pb.Reading{
 		TagId:    "MOCKTAG",
@@ -20,100 +29,15 @@ func TestInsertSingleReading(t *testing.T) {
 			Seconds: timestamppb.Now().Seconds,
 		},
 	}
-
-	mockReading2 := &pb.Reading{
-		TagId:    "MOCKTAG2",
-		DeviceId: "3212",
-		Rssi:     13,
-		Ts: &timestamp.Timestamp{
-			Seconds: timestamppb.Now().Seconds,
-		},
-	}
-
 	sh := StateHandler{}
 	sh.initStateHandler("666")
 	sh.InsertSingleReading(mockReading)
-	sh.InsertSingleReading(mockReading2)
 
-	expectedMockState := &pb.State{
-		TagId:    "666",
-		Readings: []*pb.Reading{mockReading, mockReading2},
-	}
-	actualState := sh.getState()
-	sort.SliceStable(actualState.Readings, func(i, j int) bool {
-		return actualState.Readings[i].TagId < actualState.Readings[j].TagId
-	})
-	assert.Equal(t, expectedMockState, actualState)
+	assert.Equal(t, sh.getReading(mockReading.TagId), mockReading)
 
 }
 
-func TestLessTimeDontInsertSingleReading(t *testing.T) {
-
-	time := timestamppb.Now().Seconds
-	time2 := time / 100
-
-	mockReading := &pb.Reading{
-		TagId:    "MOCKTAG",
-		DeviceId: "321",
-		Rssi:     69,
-		Ts: &timestamp.Timestamp{
-			Seconds: time,
-		},
-	}
-
-	mockReading2 := &pb.Reading{
-		TagId:    "MOCKTAG",
-		DeviceId: "321",
-		Rssi:     10,
-		Ts: &timestamp.Timestamp{
-			Seconds: time2,
-		},
-	}
-
-	sh := StateHandler{}
-	sh.initStateHandler("666")
-	sh.InsertSingleReading(mockReading)
-	sh.InsertSingleReading(mockReading2)
-	reading := sh.getReading(mockReading.TagId)
-
-	assert.Equal(t, time, reading.Ts.Seconds)
-
-}
-
-func TestMoreTimeInsertSingleReading(t *testing.T) {
-
-	time := timestamppb.Now().Seconds
-	time2 := time * 100
-
-	mockReading := &pb.Reading{
-		TagId:    "MOCKTAG",
-		DeviceId: "321",
-		Rssi:     69,
-		Ts: &timestamp.Timestamp{
-			Seconds: time,
-		},
-	}
-
-	mockReading2 := &pb.Reading{
-		TagId:    "MOCKTAG",
-		DeviceId: "321",
-		Rssi:     10,
-		Ts: &timestamp.Timestamp{
-			Seconds: time2,
-		},
-	}
-
-	sh := StateHandler{}
-	sh.initStateHandler("666")
-
-	sh.InsertSingleReading(mockReading)
-	sh.InsertSingleReading(mockReading2)
-	reading := sh.getReading(mockReading.TagId)
-	assert.Equal(t, time2, reading.Ts.Seconds)
-
-}
-
-func TestInsertMultipleReading(t *testing.T) {
+func TestMultipleGetReading(t *testing.T) {
 
 	mockReading := &pb.Reading{
 		TagId:    "MOCKTAG",
@@ -151,28 +75,92 @@ func TestInsertMultipleReading(t *testing.T) {
 		},
 	}
 
-	mockState := &pb.State{
-		TagId:    "666",
-		Readings: []*pb.Reading{mockReading, mockReading2},
+	sh := StateHandler{}
+	sh.initStateHandler("666")
+	sh.InsertSingleReading(mockReading)
+	sh.InsertSingleReading(mockReading2)
+	sh.InsertSingleReading(mockReading3)
+	sh.InsertSingleReading(mockReading4)
+	assert.Equal(t, sh.getReading(mockReading.TagId), mockReading)
+	assert.Equal(t, sh.getReading(mockReading2.TagId), mockReading2)
+	assert.Equal(t, sh.getReading(mockReading3.TagId), mockReading3)
+	assert.Equal(t, sh.getReading(mockReading4.TagId), mockReading4)
+}
+
+func TestGetState(t *testing.T) {
+	mockReading := &pb.Reading{
+		TagId:    "MOCKTAG",
+		DeviceId: "321",
+		Rssi:     69,
+		Ts: &timestamp.Timestamp{
+			Seconds: timestamppb.Now().Seconds,
+		},
 	}
 
-	mockState2 := &pb.State{
-		TagId:    "669",
-		Readings: []*pb.Reading{mockReading3, mockReading4},
+	mockState := &pb.State{
+		TagId:    "666",
+		Readings: []*pb.Reading{mockReading},
 	}
 
 	sh := StateHandler{}
-	sh.initStateHandler("669")
-	sh.InsertMultipleReadings(mockState)
-	sh.InsertMultipleReadings(mockState2)
+	sh.initStateHandler("666")
+	sh.InsertSingleReading(mockReading)
+	assert.Equal(t, sh.getState(), mockState)
+
+}
+
+func TestMultipleGetState(t *testing.T) {
+
+	mockReading := &pb.Reading{
+		TagId:    "MOCKTAG",
+		DeviceId: "321",
+		Rssi:     69,
+		Ts: &timestamp.Timestamp{
+			Seconds: timestamppb.Now().Seconds,
+		},
+	}
+
+	mockReading2 := &pb.Reading{
+		TagId:    "MOCKTAG2",
+		DeviceId: "3212",
+		Rssi:     13,
+		Ts: &timestamp.Timestamp{
+			Seconds: timestamppb.Now().Seconds,
+		},
+	}
+
+	mockReading3 := &pb.Reading{
+		TagId:    "MOCKTAG3",
+		DeviceId: "3213",
+		Rssi:     10,
+		Ts: &timestamp.Timestamp{
+			Seconds: timestamppb.Now().Seconds,
+		},
+	}
+
+	mockReading4 := &pb.Reading{
+		TagId:    "MOCKTAG4",
+		DeviceId: "3214",
+		Rssi:     10,
+		Ts: &timestamp.Timestamp{
+			Seconds: timestamppb.Now().Seconds,
+		},
+	}
+
 	expectedMockState := &pb.State{
-		TagId:    "669",
+		TagId:    "666",
 		Readings: []*pb.Reading{mockReading, mockReading2, mockReading3, mockReading4},
 	}
+
+	sh := StateHandler{}
+	sh.initStateHandler("666")
+	sh.InsertSingleReading(mockReading)
+	sh.InsertSingleReading(mockReading2)
+	sh.InsertSingleReading(mockReading3)
+	sh.InsertSingleReading(mockReading4)
 	actualState := sh.getState()
 	sort.SliceStable(actualState.Readings, func(i, j int) bool {
 		return actualState.Readings[i].TagId < actualState.Readings[j].TagId
 	})
 	assert.Equal(t, expectedMockState, actualState)
-
 }

--- a/internal/protocol/utils/state_handler.go
+++ b/internal/protocol/utils/state_handler.go
@@ -35,9 +35,9 @@ func (stateHandler *StateHandler) getReading(id string) *pb.Reading {
 }
 
 func (stateHandler *StateHandler) getState() *pb.State {
-	s := pb.State{TagId: stateHandler.TagId}
 
 	stateHandler.lock()
+	s := pb.State{TagId: stateHandler.TagId}
 	for _, reading := range stateHandler.readingsMap {
 		s.Readings = append(s.Readings, reading)
 	}


### PR DESCRIPTION
Implemented the following tests in order to test the functions in `statehandler`

- `TestInitStateHandler` tests the `initStateHandler` function.
- `TestGetReading` tests the `getReading` function while containing one reading.
- `TestMultipleGetReading` tests the `getReading` function while containing multiple readings.
- `TestGetState` test the `getState` function while containing one reading.
- `TestMultipleGetState`  tests the `getState` function while containing multiple readings.