### PR TITLE
Changes to `StateHandler` and client and server for grpc

### DIFF
--- a/internal/protocol/utils/insert_test.go
+++ b/internal/protocol/utils/insert_test.go
@@ -31,7 +31,7 @@ func TestInsertSingleReading(t *testing.T) {
 	}
 
 	sh := StateHandler{}
-	sh.initStateHandler("666")
+	sh.InitStateHandler("666")
 	sh.InsertSingleReading(mockReading)
 	sh.InsertSingleReading(mockReading2)
 
@@ -39,7 +39,7 @@ func TestInsertSingleReading(t *testing.T) {
 		TagId:    "666",
 		Readings: []*pb.Reading{mockReading, mockReading2},
 	}
-	actualState := sh.getState()
+	actualState := sh.GetState()
 	sort.SliceStable(actualState.Readings, func(i, j int) bool {
 		return actualState.Readings[i].TagId < actualState.Readings[j].TagId
 	})
@@ -71,10 +71,10 @@ func TestLessTimeDontInsertSingleReading(t *testing.T) {
 	}
 
 	sh := StateHandler{}
-	sh.initStateHandler("666")
+	sh.InitStateHandler("666")
 	sh.InsertSingleReading(mockReading)
 	sh.InsertSingleReading(mockReading2)
-	reading := sh.getReading(mockReading.TagId)
+	reading := sh.GetReading(mockReading.TagId)
 
 	assert.Equal(t, time, reading.Ts.Seconds)
 
@@ -104,11 +104,11 @@ func TestMoreTimeInsertSingleReading(t *testing.T) {
 	}
 
 	sh := StateHandler{}
-	sh.initStateHandler("666")
+	sh.InitStateHandler("666")
 
 	sh.InsertSingleReading(mockReading)
 	sh.InsertSingleReading(mockReading2)
-	reading := sh.getReading(mockReading.TagId)
+	reading := sh.GetReading(mockReading.TagId)
 	assert.Equal(t, time2, reading.Ts.Seconds)
 
 }
@@ -162,14 +162,14 @@ func TestInsertMultipleReading(t *testing.T) {
 	}
 
 	sh := StateHandler{}
-	sh.initStateHandler("669")
+	sh.InitStateHandler("669")
 	sh.InsertMultipleReadings(mockState)
 	sh.InsertMultipleReadings(mockState2)
 	expectedMockState := &pb.State{
 		TagId:    "669",
 		Readings: []*pb.Reading{mockReading, mockReading2, mockReading3, mockReading4},
 	}
-	actualState := sh.getState()
+	actualState := sh.GetState()
 	sort.SliceStable(actualState.Readings, func(i, j int) bool {
 		return actualState.Readings[i].TagId < actualState.Readings[j].TagId
 	})

--- a/internal/protocol/utils/state_hander_test.go
+++ b/internal/protocol/utils/state_hander_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestInnitStateHandler(t *testing.T) {
 	sh := StateHandler{}
-	sh.initStateHandler("666")
+	sh.InitStateHandler("666")
 
 	shMock := StateHandler{"666", make(map[string]*pb.Reading), sync.RWMutex{}}
 	assert.Equal(t, sh, shMock)
@@ -31,10 +31,10 @@ func TestGetReading(t *testing.T) {
 		},
 	}
 	sh := StateHandler{}
-	sh.initStateHandler("666")
+	sh.InitStateHandler("666")
 	sh.InsertSingleReading(mockReading)
 
-	assert.Equal(t, sh.getReading(mockReading.TagId), mockReading)
+	assert.Equal(t, sh.GetReading(mockReading.TagId), mockReading)
 
 }
 
@@ -77,15 +77,15 @@ func TestMultipleGetReading(t *testing.T) {
 	}
 
 	sh := StateHandler{}
-	sh.initStateHandler("666")
+	sh.InitStateHandler("666")
 	sh.InsertSingleReading(mockReading)
 	sh.InsertSingleReading(mockReading2)
 	sh.InsertSingleReading(mockReading3)
 	sh.InsertSingleReading(mockReading4)
-	assert.Equal(t, sh.getReading(mockReading.TagId), mockReading)
-	assert.Equal(t, sh.getReading(mockReading2.TagId), mockReading2)
-	assert.Equal(t, sh.getReading(mockReading3.TagId), mockReading3)
-	assert.Equal(t, sh.getReading(mockReading4.TagId), mockReading4)
+	assert.Equal(t, sh.GetReading(mockReading.TagId), mockReading)
+	assert.Equal(t, sh.GetReading(mockReading2.TagId), mockReading2)
+	assert.Equal(t, sh.GetReading(mockReading3.TagId), mockReading3)
+	assert.Equal(t, sh.GetReading(mockReading4.TagId), mockReading4)
 }
 
 func TestGetState(t *testing.T) {
@@ -104,9 +104,9 @@ func TestGetState(t *testing.T) {
 	}
 
 	sh := StateHandler{}
-	sh.initStateHandler("666")
+	sh.InitStateHandler("666")
 	sh.InsertSingleReading(mockReading)
-	assert.Equal(t, sh.getState(), mockState)
+	assert.Equal(t, sh.GetState(), mockState)
 
 }
 
@@ -154,12 +154,12 @@ func TestMultipleGetState(t *testing.T) {
 	}
 
 	sh := StateHandler{}
-	sh.initStateHandler("666")
+	sh.InitStateHandler("666")
 	sh.InsertSingleReading(mockReading)
 	sh.InsertSingleReading(mockReading2)
 	sh.InsertSingleReading(mockReading3)
 	sh.InsertSingleReading(mockReading4)
-	actualState := sh.getState()
+	actualState := sh.GetState()
 	sort.SliceStable(actualState.Readings, func(i, j int) bool {
 		return actualState.Readings[i].TagId < actualState.Readings[j].TagId
 	})
@@ -177,7 +177,7 @@ func TestGetStatesReadingLimit(t *testing.T) {
 	}
 
 	sh := StateHandler{}
-	sh.initStateHandler("666")
+	sh.InitStateHandler("666")
 	sh.InsertMultipleReadings(&pb.State{TagId: "666", Readings: mockReadings})
 	actualStates := sh.getStatesReadingLimit(4)
 	assert.Equal(t, mockStates[0], actualStates[0])

--- a/internal/protocol/utils/state_handler.go
+++ b/internal/protocol/utils/state_handler.go
@@ -14,7 +14,7 @@ type StateHandler struct {
 	mutex       sync.RWMutex
 }
 
-func (stateHandler *StateHandler) initStateHandler(id string) {
+func (stateHandler *StateHandler) InitStateHandler(id string) {
 	stateHandler.lock()
 	stateHandler.TagId = id
 	stateHandler.readingsMap = make(map[string]*pb.Reading)
@@ -29,14 +29,14 @@ func (stateHandler *StateHandler) unLock() {
 	stateHandler.mutex.Unlock()
 }
 
-func (stateHandler *StateHandler) getReading(id string) *pb.Reading {
+func (stateHandler *StateHandler) GetReading(id string) *pb.Reading {
 	stateHandler.lock()
 	r := stateHandler.readingsMap[id]
 	stateHandler.unLock()
 	return r
 }
 
-func (stateHandler *StateHandler) getState() *pb.State {
+func (stateHandler *StateHandler) GetState() *pb.State {
 
 	stateHandler.lock()
 	s := pb.State{TagId: stateHandler.TagId}
@@ -48,7 +48,7 @@ func (stateHandler *StateHandler) getState() *pb.State {
 }
 
 func (stateHandler *StateHandler) getStateSorted() *pb.State {
-	state := stateHandler.getState()
+	state := stateHandler.GetState()
 	sort.SliceStable(state.Readings, func(i, j int) bool {
 		return state.Readings[i].TagId < state.Readings[j].TagId
 	})
@@ -59,7 +59,7 @@ func (stateHandler *StateHandler) getStateSorted() *pb.State {
 func (stateHandler *StateHandler) getStatesReadingLimit(limit int) []*pb.State {
 
 	states := []*pb.State{}
-	stateWhole := stateHandler.getStateSorted() //Not sure how to implement a test for getStatesReadingLimit if this is not sorted (using the getState function)
+	stateWhole := stateHandler.getStateSorted() //Not sure how to implement a test for GetStatesReadingLimit if this is not sorted (using the GetState function)
 	stateChunk := &pb.State{TagId: stateWhole.TagId, Readings: []*pb.Reading{}}
 	i := 0
 	for _, reading := range stateWhole.Readings {


### PR DESCRIPTION
grpc client:
- implemented `StateHandler` into the client
- inserted multiple readings of a state

grpc server:
- only acks a request from the client and does not mock any data for now

state handler:
- made some functions public to be accessed in gprc client
- updated corresponding tests