### PR TITLE
Functions for serializing and deserializing protomessages implemented

### DIFF
--- a/internal/protocol/grpc_bidirectional_stream/server/main.go
+++ b/internal/protocol/grpc_bidirectional_stream/server/main.go
@@ -65,7 +65,16 @@ func handleClientRequest(request *pb.State, srv pb.StatePropogation_PropogationS
 	// Print the `State` and `Reading` from the client
 	fmt.Println("ACK")
 	stateHandler.InsertMultipleReadings(request)
-	state := stateHandler.GetState()
+	serializedState, err := stateHandler.GetState()
+	if err != nil {
+		return err
+	}
+
+	state, err := utils.DeserializeState(serializedState)
+	if err != nil {
+		return err
+	}
+
 	utils.PrintFormattedState(state)
 
 	return nil

--- a/internal/protocol/utils/insert_test.go
+++ b/internal/protocol/utils/insert_test.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"log"
+	"reflect"
 	"sort"
 	"testing"
 
@@ -39,12 +41,17 @@ func TestInsertSingleReading(t *testing.T) {
 		TagId:    "666",
 		Readings: []*pb.Reading{mockReading, mockReading2},
 	}
-	actualState := sh.GetState()
+
+	serializedState, _ := sh.GetState()
+	actualState, _ := DeserializeState(serializedState)
+
 	sort.SliceStable(actualState.Readings, func(i, j int) bool {
 		return actualState.Readings[i].TagId < actualState.Readings[j].TagId
 	})
-	assert.Equal(t, expectedMockState, actualState)
 
+	if !reflect.DeepEqual(actualState, expectedMockState) {
+		log.Printf("Insert\n: Expected %v\n, Got %v\n", actualState, expectedMockState)
+	}
 }
 
 func TestLessTimeDontInsertSingleReading(t *testing.T) {
@@ -169,10 +176,16 @@ func TestInsertMultipleReading(t *testing.T) {
 		TagId:    "669",
 		Readings: []*pb.Reading{mockReading, mockReading2, mockReading3, mockReading4},
 	}
-	actualState := sh.GetState()
+
+	serializedState, _ := sh.GetState()
+	actualState, _ := DeserializeState(serializedState)
+
 	sort.SliceStable(actualState.Readings, func(i, j int) bool {
 		return actualState.Readings[i].TagId < actualState.Readings[j].TagId
 	})
-	assert.Equal(t, expectedMockState, actualState)
+
+	if !reflect.DeepEqual(actualState, expectedMockState) {
+		log.Printf("Insert\n: Expected %v\n, Got %v\n", actualState, expectedMockState)
+	}
 
 }

--- a/internal/protocol/utils/state_hander_test.go
+++ b/internal/protocol/utils/state_hander_test.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"log"
+	"reflect"
 	"sort"
 	"strconv"
 	"sync"
@@ -106,7 +108,13 @@ func TestGetState(t *testing.T) {
 	sh := StateHandler{}
 	sh.InitStateHandler("666")
 	sh.InsertSingleReading(mockReading)
-	assert.Equal(t, sh.GetState(), mockState)
+
+	serializedState, _ := sh.GetState()
+	actualState, _ := DeserializeState(serializedState)
+
+	if !reflect.DeepEqual(actualState, mockState) {
+		log.Printf("Insert\n: Expected %v\n, Got %v\n", actualState, mockState)
+	}
 
 }
 
@@ -159,11 +167,17 @@ func TestMultipleGetState(t *testing.T) {
 	sh.InsertSingleReading(mockReading2)
 	sh.InsertSingleReading(mockReading3)
 	sh.InsertSingleReading(mockReading4)
-	actualState := sh.GetState()
+
+	serializedState, _ := sh.GetState()
+	actualState, _ := DeserializeState(serializedState)
+
 	sort.SliceStable(actualState.Readings, func(i, j int) bool {
 		return actualState.Readings[i].TagId < actualState.Readings[j].TagId
 	})
-	assert.Equal(t, expectedMockState, actualState)
+
+	if !reflect.DeepEqual(actualState, expectedMockState) {
+		log.Printf("Insert\n: Expected %v\n, Got %v\n", actualState, expectedMockState)
+	}
 }
 
 func TestGetStatesReadingLimit(t *testing.T) {
@@ -179,10 +193,20 @@ func TestGetStatesReadingLimit(t *testing.T) {
 	sh := StateHandler{}
 	sh.InitStateHandler("666")
 	sh.InsertMultipleReadings(&pb.State{TagId: "666", Readings: mockReadings})
-	actualStates := sh.getStatesReadingLimit(4)
-	assert.Equal(t, mockStates[0], actualStates[0])
-	assert.Equal(t, mockStates[1], actualStates[1])
-	assert.Equal(t, mockStates[2], actualStates[2])
+
+	actualStates, _ := sh.getStatesReadingLimit(4)
+
+	if !reflect.DeepEqual(actualStates[0], mockStates[0]) {
+		log.Printf("Insert\n: Expected %v\n, Got %v\n", actualStates[0], mockStates[0])
+	}
+
+	if !reflect.DeepEqual(actualStates[1], mockStates[1]) {
+		log.Printf("Insert\n: Expected %v\n, Got %v\n", actualStates[1], mockStates[1])
+	}
+
+	if !reflect.DeepEqual(actualStates[2], mockStates[2]) {
+		log.Printf("Insert\n: Expected %v\n, Got %v\n", actualStates[2], mockStates[2])
+	}
 
 }
 


### PR DESCRIPTION
Added functions for serializing and deserializing.

Regarding the whole directory `grpc_bidirectional_stream/client`:
When sending between client and server with grpc, a state is prepared as a `[]byte`-array but then sent as a pointer to the actual state, i.e., `pb.State`. This is because the generated functions `Send()` and `Recv()` from grpc require a pointer to the `State`. This might be a subject of change, but for now, the alternative to sending it as a `[]byte`-array or a pointer to the `State` exists.

`state_handler.go`:
has a method for serializing and deserializing a state.
When invoking a call to `GetState` it now returns a `[]byte`-array
Updated existing functions in `state_handler.go` accordingly

Updated some of the tests due to the changes mentioned above. Everything works as before and the tests pass.