### PR TITLE
Implemented directHandler

### DIFF
--- a/internal/backend/handlers/directHandler.go
+++ b/internal/backend/handlers/directHandler.go
@@ -1,0 +1,46 @@
+package handlers
+
+import (
+	"fmt"
+
+	structs "github.com/Domilz/d7017e-mesh-network/internal/backend/grpcServer/forms"
+	pb "github.com/Domilz/d7017e-mesh-network/internal/protocol/protofiles/tag"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type DirectHandler struct {
+	//Object for log
+}
+
+func (directHandler *DirectHandler) FillOutForm(reading *pb.Reading) {
+	timeForSentRecived := &structs.Time{
+		Seconds: int(timestamppb.Now().Seconds),
+		Nanos:   int(timestamppb.Now().Nanos),
+	}
+
+	newChainDelayStruct := &structs.Chain_delay{
+		Name:     "tagbackend",
+		Sent:     *timeForSentRecived,
+		Received: *timeForSentRecived,
+	}
+
+	newReadingStruct := &structs.Reading{
+		Rp_id:       reading.RpId,
+		Rssi:        int(reading.Rssi),
+		Tag_id:      reading.TagId,
+		Type:        "BLE",
+		Chain_delay: []structs.Chain_delay{*newChainDelayStruct},
+	}
+
+	newRssiForm := &structs.RssiForm{
+		Readings: []structs.Reading{*newReadingStruct},
+	}
+
+	directHandler.SendFormToCentral(newRssiForm)
+}
+
+// Should send to api but don't have access so sending to log instead when
+// it is created. Using print so the system does not complain.
+func (directHandler *DirectHandler) SendFormToCentral(rssiForm *structs.RssiForm) {
+	fmt.Println(rssiForm)
+}

--- a/internal/backend/handlers/directHandler.go
+++ b/internal/backend/handlers/directHandler.go
@@ -12,7 +12,7 @@ type DirectHandler struct {
 	//Object for log
 }
 
-func (directHandler *DirectHandler) FillOutForm(reading *pb.Reading) {
+func (directHandler *DirectHandler) FillOutAndSendForm(reading *pb.Reading) {
 	timeForSentRecived := &structs.Time{
 		Seconds: int(timestamppb.Now().Seconds),
 		Nanos:   int(timestamppb.Now().Nanos),
@@ -36,11 +36,11 @@ func (directHandler *DirectHandler) FillOutForm(reading *pb.Reading) {
 		Readings: []structs.Reading{*newReadingStruct},
 	}
 
-	directHandler.SendFormToCentral(newRssiForm)
+	directHandler.sendFormToCentral(newRssiForm)
 }
 
 // Should send to api but don't have access so sending to log instead when
 // it is created. Using print so the system does not complain.
-func (directHandler *DirectHandler) SendFormToCentral(rssiForm *structs.RssiForm) {
+func (directHandler *DirectHandler) sendFormToCentral(rssiForm *structs.RssiForm) {
 	fmt.Println(rssiForm)
 }


### PR DESCRIPTION
Implemented directHandler with **DirectHandler** struct and two functions; **FillOutForm** that fills out the RSSI-form and **SendFormToCentral** that sends the RSSI-form to Epiroc. It is unfinished, as soon as the Log is implemented you only need to implement it in **directHandler.go**.