### PR TITLE
Added Changes to debuglog made in demo

### DIFF
--- a/pkg/backend/grpcServer/grpc_server.go
+++ b/pkg/backend/grpcServer/grpc_server.go
@@ -94,3 +94,13 @@ func StartGrpcServer() {
 		log.Fatalf("failed to build server: %v", err)
 	}
 }
+
+func SideStepGRPCServer(serializedState []byte) {
+	state, err := utils.DeserializeState(serializedState)
+	if err != nil {
+		log.Println("Error during DeserializeState", err)
+	} else {
+		backendStateHandler.InsertMultipleReadings(state)
+	}
+
+}


### PR DESCRIPTION
ByteArrays posted to debug-Log handles as a byteArray representation of a string, added method to parse it to a byteArray with `stringTOByteArr`

Added `SideStepGRPCServer` so that debug-Log server can insert readings into the `backendStateHandler` of the server