### PR TITLE
Implemented UpdateReadingofSelf

### DIFF
--- a/pkg/protocol/tag/client.go
+++ b/pkg/protocol/tag/client.go
@@ -68,8 +68,9 @@ func (client *Client) SendStateToServer() {
 
 }
 
-func (client *Client) UpdateReadingofSelf(rpId string) {
-
+// When a tag sees a beacon
+func (client *Client) UpdateReadingofSelf(rpId string, rssi int32) {
+	client.stateHandler.UpdateReadingofSelf(rpId, rssi)
 }
 
 func GetClient() *Client {

--- a/pkg/protocol/utils/state_hander_test.go
+++ b/pkg/protocol/utils/state_hander_test.go
@@ -179,6 +179,22 @@ func TestMultipleGetState(t *testing.T) {
 		log.Printf("Insert\n: Expected %v\n, Got %v\n", actualState, expectedMockState)
 	}
 }
+func TestUpdateReadingofSelf(t *testing.T) {
+	sh := StateHandler{}
+	sh.InitStateHandler("RandomUniqueId")
+	mockReading := &pb.Reading{
+		TagId: "RandomUniqueId",
+		RpId:  "11111",
+		Rssi:  10,
+		Ts: &timestamp.Timestamp{
+			Seconds: timestamppb.Now().Seconds,
+		},
+	}
+	sh.InsertSingleReading(mockReading)
+	sh.UpdateReadingofSelf("22222", 5)
+	assert.Equal(t, sh.GetReading("RandomUniqueId").RpId, "22222")
+
+}
 
 // For testing
 func generateMockReading(count int) []*pb.Reading {

--- a/pkg/protocol/utils/state_handler.go
+++ b/pkg/protocol/utils/state_handler.go
@@ -5,6 +5,7 @@ import (
 
 	pb "github.com/Domilz/d7017e-mesh-network/pkg/protocol/protofiles/tag"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type StateHandler struct {
@@ -80,4 +81,12 @@ func DeserializeState(stateArray []byte) (*pb.State, error) {
 	}
 
 	return stateMessage, nil
+}
+
+func (stateHandler *StateHandler) UpdateReadingofSelf(rpId string, rssi int32) {
+	stateHandler.lock()
+	r := &pb.Reading{TagId: stateHandler.TagId, RpId: rpId, Rssi: rssi, Ts: timestamppb.Now(), IsDirect: 1}
+	stateHandler.readingsMap[stateHandler.TagId] = r
+	stateHandler.unLock()
+
 }


### PR DESCRIPTION
Implemented `UpdateReadingofSelf` in `state_handler.go` and test for it in `state_handler_test.go` 
The method should be called when a tag sees a beacon, updates the  tag reading of itself  with the beacons id and sets time to the current time and `IsDirect` to 1