### PR TITLE
Added function to populate the reference point cache with mocked data

### DIFF
--- a/pkg/backend/grpcServer/handlers/backendStateHandler.go
+++ b/pkg/backend/grpcServer/handlers/backendStateHandler.go
@@ -11,18 +11,17 @@ import (
 )
 
 type BackendStateHandler struct {
-	TagId         string
-	readingsMap   map[string]*pb.Reading
-	mutex         sync.RWMutex
-	directHandler *DirectHandler
-	//indirectHandler *IndirectHandler
-
+	TagId           string
+	readingsMap     map[string]*pb.Reading
+	mutex           sync.RWMutex
+	directHandler   *DirectHandler
+	indirectHandler *IndirectHandler
 }
 
 func (stateHandler *BackendStateHandler) InitStateHandler(id string, sLogServer *sentLog.SentLogServer) {
 	stateHandler.lock()
 	stateHandler.directHandler = InitDirectHandler(sLogServer)
-	//stateHandler.directHandler = InitIndirectHandler(sLogServer) //When implemented
+	stateHandler.indirectHandler = InitIndirectHandler(sLogServer) //When implemented
 	stateHandler.TagId = id
 	stateHandler.readingsMap = make(map[string]*pb.Reading)
 	stateHandler.unLock()
@@ -98,7 +97,7 @@ func (stateHandler *BackendStateHandler) InsertSingleReading(reading *pb.Reading
 		if reading.IsDirect == 0 {
 			println("Recieved indirect reading for tag: ", reading.TagId)
 			//Send to indirectHandler in go routine
-			//go stateHandler.indirectHandler.FillOutAndSendForm()
+			go stateHandler.indirectHandler.FillOutAndSendForm(reading)
 		} else if reading.IsDirect == 1 {
 
 			go stateHandler.directHandler.FillOutAndSendForm(reading)

--- a/pkg/backend/grpcServer/handlers/indirectHandler.go
+++ b/pkg/backend/grpcServer/handlers/indirectHandler.go
@@ -14,6 +14,16 @@ type IndirectHandler struct {
 	rpCache *ReferencePointCache
 }
 
+func InitIndirectHandler(sLog *sentLog.SentLogServer) *IndirectHandler {
+	indirectHandler := &IndirectHandler{}
+	indirectHandler.sentLog = sLog
+	rpCache := InitReferencePointCache()
+	rpCache.PopulateWithMockedData()
+	indirectHandler.rpCache = rpCache
+
+	return indirectHandler
+}
+
 func (indirectHanddler *IndirectHandler) FillOutAndSendForm(reading *pb.Reading) {
 	createTime := &structs.Time{
 		Seconds: int(timestamppb.Now().Seconds), //Change later.

--- a/pkg/backend/grpcServer/handlers/referencePointCache.go
+++ b/pkg/backend/grpcServer/handlers/referencePointCache.go
@@ -37,3 +37,20 @@ func (rpCache *ReferencePointCache) GetXYZ(rp_id string) (*structs.XYZ, error) {
 
 	return nil, errors.New("No such reference point id.")
 }
+
+func (rpCache *ReferencePointCache) PopulateWithMockedData() {
+	for i := 1; i < 27; i++ {
+
+		c := rune(i + 96)
+		x := string(c) + string(c)
+		key := x + ":" + x + ":" + x + ":" + x + ":" + x + ":" + x
+		pos := &structs.XYZ{
+			X: (float32(i)),
+			Y: (float32(i)),
+			Z: (float32(i)),
+		}
+		rpCache.AddReferencePointAndPosition(key, pos)
+
+	}
+
+}

--- a/pkg/backend/grpcServer/handlers/referencePointCache_test.go
+++ b/pkg/backend/grpcServer/handlers/referencePointCache_test.go
@@ -126,3 +126,8 @@ func TestGetXYZError(t *testing.T) {
 
 	assert.Equal(t, "No such reference point id.", err.Error())
 }
+
+func TestPopulateWithMockedData(t *testing.T) {
+	rpCache := InitReferencePointCache()
+	rpCache.PopulateWithMockedData()
+}


### PR DESCRIPTION
`PopulateWithMockedData` adds mocked data to the reference point cache, 
Added `InitIndirectHandler`, sets up the indirect handler `PopulateWithMockedData `is called here.