### PR TITLE
Fixed filepath for databases and html files

### DIFF
--- a/pkg/backend/grpcServer/handlers/stateDatabaseHandler.go
+++ b/pkg/backend/grpcServer/handlers/stateDatabaseHandler.go
@@ -92,6 +92,6 @@ func (stateDatabaseHandler *StateDatabaseHandler) LoadFromDB() []pb.Reading {
 		readings = append(readings, reading)
 
 	}
-	log.Print("Loaded from DB:", readings)
+	log.Printf("StateDatabaseHandler loaded %v readings from DB, loaded readings: %v", len(readings), readings)
 	return readings
 }

--- a/pkg/backend/main.go
+++ b/pkg/backend/main.go
@@ -6,6 +6,8 @@ import (
 	sentLog "github.com/Domilz/d7017e-mesh-network/pkg/backend/sentLog"
 )
 
+var backendPath = "pkg/backend/"
+
 func Main() {
 	StartBackend()
 	select {}
@@ -19,17 +21,17 @@ func StartBackend() {
 }
 
 func StartDebugLog() {
-	debugLog.StartDebugLogServer("debugLog/database/DebugLogDatabase.db", "./debugLog/debugLogFormat.html")
+	debugLog.StartDebugLogServer(backendPath+"debugLog/database/DebugLogDatabase.db", backendPath+"debugLog/debugLogFormat.html")
 }
 
 func StartSentLog() *sentLog.SentLogServer {
-	sentLogServer := sentLog.StartSentLogServer("sentLog/database/SentLogDatabase.db", "./sentLog/sentLogFormat.html")
+	sentLogServer := sentLog.StartSentLogServer(backendPath+"sentLog/database/SentLogDatabase.db", backendPath+"sentLog/sentLogFormat.html")
 	return sentLogServer
 
 }
 
 func StartGRPCServer(sLogServer *sentLog.SentLogServer) {
 
-	server.StartGrpcServer(sLogServer, "stateLog/database/state.db", "./stateLog/stateLogFormat.html")
+	server.StartGrpcServer(sLogServer, backendPath+"stateLog/database/state.db", backendPath+"stateLog/stateLogFormat.html")
 
 }


### PR DESCRIPTION
Fixed filepaths for when opening databases and html files for backend, the path is now based on the root directory of the project rather than from the backend folder
From the project root directory run `go build .\lib\main.go to` or equivalent to build the files, then run it with `main.exe backend` or equivalent to run the backend.


In `StateDatabaseHandler`  in method `LoadFromDB`  changed printout to include the number of readings found in the database.