### PR TITLE
Added fetch of mocked data for beacondata

### DIFF
--- a/pkg/backend/guiPlotter/gui_plotter_server.go
+++ b/pkg/backend/guiPlotter/gui_plotter_server.go
@@ -111,7 +111,8 @@ func WebSocketHandler(w http.ResponseWriter, r *http.Request) {
 			if request == "getInitialData" {
 				log.Printf("Establishing connection")
 				// Handle the initial data request here
-				data := Data{Beacons: getBeaconsForStartup(), Tags: getTagsForStartup()}
+				// data := Data{Beacons: getBeaconsForStartup(), Tags: getTagsForStartup()}
+				data := guiPlotter.initData
 
 				// Marshal the initial data to JSON and send it to the client
 				jsonData, _ := json.Marshal(data)
@@ -235,9 +236,4 @@ func getTagsForStartup() []Tag {
 	list = append(list, *tag3)
 
 	return list
-}
-
-func (guiPlotter *GUIPlotter) getTagDataFromSentLog() []Tag {
-	//guiPlotter.sentLog.G
-	return nil
 }

--- a/pkg/backend/sentLog/referencePointCache.go
+++ b/pkg/backend/sentLog/referencePointCache.go
@@ -37,7 +37,7 @@ func (rpCache *ReferencePointCache) GetXYZ(rp_id string) (*structs.XYZ, error) {
 
 	return nil, errors.New("No such reference point id.")
 }
-func (rpCache *ReferencePointCache) getAllReferencePoints() ([]string, []structs.XYZ) {
+func (rpCache *ReferencePointCache) GetAllReferencePoints() ([]string, []structs.XYZ) {
 	rpCache.mutex.Lock()
 	sArr := []string{}
 	positions := []structs.XYZ{}


### PR DESCRIPTION
Added fetch of mocked data for beacondata instead of initializing static data.  This is for our new feature `GUIPlotter` which is pretty cool.
- getter for referencepoints `getAllReferencePoints` is public and changed to `GetAllReferencePoints`
-  preparing data for beacon is now made through `prepInitialBeaconDataForGuiPlotter`
- `SentLogServer` handles this and is sent to the backend