### PR TITLE
181 fix logic to be able to complete acceptence test 2

### DIFF
--- a/pkg/protocol/utils/state_hander_test.go
+++ b/pkg/protocol/utils/state_hander_test.go
@@ -20,6 +20,16 @@ func TestInitStateHandler(t *testing.T) {
 	sh.InitStateHandler("666")
 
 	shMock := StateHandler{"666", make(map[string]*pb.Reading), sync.RWMutex{}}
+	r := &pb.Reading{
+		TagId: "666",
+		RpId:  "null",
+		Rssi:  0,
+		Ts: &timestamp.Timestamp{
+			Seconds: 0,
+		},
+		IsDirect: 2,
+	}
+	shMock.readingsMap["666"] = r
 	assert.Equal(t, sh, shMock)
 
 }

--- a/pkg/protocol/utils/state_hander_test.go
+++ b/pkg/protocol/utils/state_hander_test.go
@@ -199,6 +199,23 @@ func TestUpdateReadingofSelf(t *testing.T) {
 
 }
 
+func TestAcceptenceTest2(t *testing.T) {
+	sh1 := StateHandler{}
+	sh1.InitStateHandler("tagId1")
+	sh2 := StateHandler{}
+	sh2.InitStateHandler("tagId2")
+
+	state2 := sh2.GetState()
+	sh1.InsertMultipleReadings(state2)
+
+	sh1.UpdateReadingofSelf("rpId1", -10)
+	actualState := sh1.GetState()
+
+	assert.Equal(t, actualState.Readings[0].RpId, "rpId1")
+	assert.Equal(t, actualState.Readings[1].RpId, "rpId1")
+
+}
+
 // For testing
 func generateMockReading(count int) []*pb.Reading {
 	var readings []*pb.Reading

--- a/pkg/protocol/utils/state_handler.go
+++ b/pkg/protocol/utils/state_handler.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	pb "github.com/Domilz/d7017e-mesh-network/pkg/protocol/protofiles/tag"
+	"github.com/golang/protobuf/ptypes/timestamp"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -18,6 +19,16 @@ func (stateHandler *StateHandler) InitStateHandler(id string) {
 	stateHandler.lock()
 	stateHandler.TagId = id
 	stateHandler.readingsMap = make(map[string]*pb.Reading)
+	reading := &pb.Reading{
+		TagId: id,
+		RpId:  "null",
+		Rssi:  0,
+		Ts: &timestamp.Timestamp{
+			Seconds: 0,
+		},
+		IsDirect: 2,
+	}
+	stateHandler.readingsMap[id] = reading
 	stateHandler.unLock()
 }
 
@@ -87,6 +98,14 @@ func (stateHandler *StateHandler) UpdateReadingofSelf(rpId string, rssi int32) {
 	stateHandler.lock()
 	r := &pb.Reading{TagId: stateHandler.TagId, RpId: rpId, Rssi: rssi, Ts: timestamppb.Now(), IsDirect: 1}
 	stateHandler.readingsMap[stateHandler.TagId] = r
+	for _, reading := range stateHandler.readingsMap {
+		if reading.RpId == "null" {
+			reading.RpId = rpId
+			reading.Ts = timestamppb.Now()
+			reading.Rssi = rssi
+			reading.IsDirect = 0
+		}
+	}
 	stateHandler.unLock()
 
 }


### PR DESCRIPTION
When `InitStateHandler` is called a reading of the tag with a rpId with the value of "null" is added to the map.

When UpdateReadingofSelf is called (when a reference point is seen) all readings with a rpId of "null" is change to the seen reference points id.

Added test to show this, see `TestAcceptenceTest2`